### PR TITLE
デザイン調整その2

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,8 +9,8 @@
 
     <main class="Main">
       <div class="Container">
-        <h1>{{ .Params.Title }}</h1>
         <article class="Article">
+          <h2>{{ .Params.Title }}</h2>
           {{ .Content }}
         </article>
       </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,8 @@
 <header class="Header">
-  <div class="Container">
-    <img src="{{ .Site.BaseURL }}/img/logo.svg" class="Header__Logo" title="FRESH!" role="img">
-  </div>
+  <h1 class="Container">
+    <a href="{{ .Site.BaseURL }}">
+    <img src="{{ .Site.BaseURL }}img/logo.svg" class="Header__Logo" title="FRESH!" />
+    <span style="display: inline-block;">Accessibility Guidelines</span>
+    </a>
+  </h1>
 </header>

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -30,7 +30,7 @@
 }
 
 .Article > * {
-  margin: 1em 4vw;
+  margin: 1em 3.125vw;
 }
 
 .Footer {

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2,7 +2,7 @@
 
 .Container {
   margin: 0 auto;
-  padding: 0 1vw;
+  padding: 0 3.125vw; /* = 10px viewport-width: 320px */
   max-width: 90rem;
   height: 100%;
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -8,14 +8,20 @@
 }
 
 .Header {
-  height: 6.8rem;
+  margin-bottom: 3rem;
+  padding: 1.5rem 0;
   background-color: #383838;
   box-shadow: 0px 2px 8px currentColor;
 }
 
+.Header a {
+  color: #fff;
+}
+
 .Header__Logo {
-  margin: 1rem 0;
+  margin: 0;
   height: 4.8rem;
+  vertical-align: -0.25em;
 }
 
 .Article {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -18,7 +18,23 @@ h1 {
 }
 
 h2 {
+  font-size: 3.4rem;
+}
+
+h3 {
   font-size: 2.8rem;
+}
+
+h4 {
+  font-size: 2.4rem;
+}
+
+h5 {
+  font-size: 2.2rem;
+}
+
+h6 {
+  font-size: 2rem;
 }
 
 a {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -13,6 +13,12 @@ body {
   background-color: #f9f9f9;
 }
 
+@media (max-width: 414px) {
+  body {
+    font-size: 1.6rem;
+  }
+}
+
 h1 {
   font-size: 4rem;
   line-height: 1.2;

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -15,10 +15,12 @@ body {
 
 h1 {
   font-size: 4rem;
+  line-height: 1.2;
 }
 
 h2 {
   font-size: 3.4rem;
+  line-height: 1.2;
 }
 
 h3 {


### PR DESCRIPTION
## やったこと

- [x] 狭い画面の時の画面の余白
- [x] h6が本文より小さくなるのでジャンプ率を調整
- [x] ガイドライントップに戻るリンクが無かったのでHeader に追加
- [x] ページごとのタイトルは `.Article` 直下に `<h2>` で配置
- [x] Article の横の余白を画面横の余白と合わせる
- [x] 狭い画面のフォントサイズを小さめにする

## 結果

### 狭い画面

![narrow_screen](https://user-images.githubusercontent.com/6724665/26873582-48b0bb5c-4bb5-11e7-9368-a6e016c2b0ee.png)

### 広い画面

![wide_screen](https://user-images.githubusercontent.com/6724665/26873562-3ac610c8-4bb5-11e7-9c16-1d1539898463.png)
